### PR TITLE
Prevent preg_match detecting character range

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -69,7 +69,7 @@ class Hooks implements \ArrayAccess {
     // all after hooks are always called.
     // The combination of first + after hooks can be used to implement caching.
     function trigger($event, array $args = []) {
-        if (preg_match('/^echo_([\w-.]+)$/', $event, $match)) {
+        if (preg_match('/^echo_([\w.-]+)$/', $event, $match)) {
             if (is_file($file = "templates/$match[1].php")) {
                 isolatedRequire($file, ["context" => $this->context, "hooks" => $this]);
             }


### PR DESCRIPTION
    preg_match(): Compilation failed: invalid range in character class at offset 10 in /www/KanbaniWebViewer/helpers.php:72
    #0 [internal function]: Kanbani\{closure}(2, 'preg_match(): C...', '/www/KanbaniWeb...', 72, Array)
    #1 /www/KanbaniWebViewer/helpers.php(72): preg_match('/^echo_([\\w-.]+...', 'start', NULL)
    #2 /www/KanbaniWebViewer/helpers.php(51): Kanbani\Hooks->trigger('start', Array)
    #3 /www/KanbaniWebViewer/helpers.php(325): Kanbani\Hooks->__call('start', Array)
    #4 /www/KanbaniWebViewer/helpers.php(299): Kanbani\initialize()
    #5 /www/KanbaniWebViewer/index.php(16): Kanbani\initializeGlobal()
    #6 {main}